### PR TITLE
added role_requirements.Any\All behaviour to the authorize decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ async def user_with_scope_and_roles(
 ```
 
 
-### Role Requirements
-To require at least one of the specified roles, you can use the role_requirement parameter with the value 
-RoleRequirement.ANY:
+### Role Requirements and Multiple Roles
+The `@authorize` decorator is capable of specifying multiple roles as a list of string, which will be checked against the user's roles. 
+If **all** the roles are found, the user is authorized.
+
+To require the user to have **at least one** of the specified roles, you can use the `role_requirement` parameter with the 
+value `RoleRequirement.ANY`:
 
 ``` python
-Copy code
 @app.get("/user_with_scope_and_roles_any")
 @authorize("user_impersonation", roles=["admin","superuser"], role_requirement=RoleRequirement.ANY)
 async def user_with_scope_and_roles_any(
@@ -99,7 +101,7 @@ async def user_with_scope_and_roles_any(
 ):
     # code here
 ```
-Note that `RoleRequirement.ALL` is the default behavior and does not need to be specified.
+> **NOTE:** `RoleRequirement.ALL` is the default behavior and does not need to be specified.
 
 ## Register your application within your Azure AD tenant
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ async def user_with_scope_and_roles(
 ```
 
 
+### Role Requirements
+To require at least one of the specified roles, you can use the role_requirement parameter with the value 
+RoleRequirement.ANY:
+
+``` python
+Copy code
+@app.get("/user_with_scope_and_roles_any")
+@authorize("user_impersonation", roles=["admin","superuser"], role_requirement=RoleRequirement.ANY)
+async def user_with_scope_and_roles_any(
+    request: Request, token=Depends(oauth2_scheme(options=api_options))
+):
+    # code here
+```
+Note that `RoleRequirement.ALL` is the default behavior and does not need to be specified.
+
 ## Register your application within your Azure AD tenant
 
 There are two applications to register:

--- a/aad_fastapi/aad_decorators.py
+++ b/aad_fastapi/aad_decorators.py
@@ -16,9 +16,10 @@ from .roles.role_validator import RoleValidator
 
 
 def authorize(
-        scopes: typing.Union[str, typing.Sequence[str]] = None,
-        roles: typing.Union[str, typing.Sequence[str]] = None,
-        role_requirement: RoleRequirement = RoleRequirement.ALL):
+    scopes: typing.Union[str, typing.Sequence[str]] = None,
+    roles: typing.Union[str, typing.Sequence[str]] = None,
+    role_requirement: RoleRequirement = RoleRequirement.ALL,
+):
     """authorize decorator. you can specify scopes and (or) roles"""
 
     def wrapper(endpoint):
@@ -36,7 +37,9 @@ def authorize(
             user_roles_list = user.roles_id or []
 
             role_validator = RoleValidator(mandatory_roles_list, role_requirement)
-            if len(mandatory_roles_list) > 0 and not role_validator.validate_roles(user_roles_list):
+            if len(mandatory_roles_list) > 0 and not role_validator.validate_roles(
+                user_roles_list
+            ):
                 raise HTTPException(status_code=403, detail="Unauthorized role")
 
             if inspect.iscoroutinefunction(endpoint):
@@ -52,7 +55,7 @@ def authorize(
 
 
 def oauth2_scheme(
-        options: AzureAdSettings = None, env_path: Optional[str] = None, **kwargs
+    options: AzureAdSettings = None, env_path: Optional[str] = None, **kwargs
 ):
     """get the OAUTH2 schema used for API Authentication"""
 

--- a/aad_fastapi/aad_decorators.py
+++ b/aad_fastapi/aad_decorators.py
@@ -20,7 +20,12 @@ def authorize(
     roles: typing.Union[str, typing.Sequence[str]] = None,
     role_requirement: RoleRequirement = RoleRequirement.ALL,
 ):
-    """authorize decorator. you can specify scopes and (or) roles"""
+    """
+    Decorator to authorize a route
+    :param scopes: list of scopes
+    :param roles: list of roles to validate
+    :param role_requirement: role requirement (RoleRequirement.ALL or RoleRequirement.ANY)
+    """
 
     def wrapper(endpoint):
         @wraps(endpoint)
@@ -57,7 +62,7 @@ def authorize(
 def oauth2_scheme(
     options: AzureAdSettings = None, env_path: Optional[str] = None, **kwargs
 ):
-    """get the OAUTH2 schema used for API Authentication"""
+    """get the OAuth2 schema used for API Authentication"""
 
     if options is None:
         options = AzureAdSettings(_env_file=env_path)

--- a/aad_fastapi/roles/all_role_validator.py
+++ b/aad_fastapi/roles/all_role_validator.py
@@ -4,5 +4,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 
 class AllRoleValidator(RoleValidatorInterface):
-    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+    def validate_roles(
+        self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
+    ) -> bool:
         return all(mandatory_role in user_roles for mandatory_role in mandatory_roles)

--- a/aad_fastapi/roles/all_role_validator.py
+++ b/aad_fastapi/roles/all_role_validator.py
@@ -4,6 +4,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 
 class AllRoleValidator(RoleValidatorInterface):
+    """Validate that all mandatory roles are present in the user roles"""
     def validate_roles(
         self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
     ) -> bool:

--- a/aad_fastapi/roles/all_role_validator.py
+++ b/aad_fastapi/roles/all_role_validator.py
@@ -1,0 +1,8 @@
+import typing
+
+from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
+
+
+class AllRoleValidator(RoleValidatorInterface):
+    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+        return all(mandatory_role in user_roles for mandatory_role in mandatory_roles)

--- a/aad_fastapi/roles/all_role_validator.py
+++ b/aad_fastapi/roles/all_role_validator.py
@@ -5,6 +5,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 class AllRoleValidator(RoleValidatorInterface):
     """Validate that all mandatory roles are present in the user roles"""
+
     def validate_roles(
         self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
     ) -> bool:

--- a/aad_fastapi/roles/any_role_validator.py
+++ b/aad_fastapi/roles/any_role_validator.py
@@ -4,6 +4,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 
 class AnyRoleValidator(RoleValidatorInterface):
+    """Validate that at least one mandatory role is present in the user roles"""
     def validate_roles(
         self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
     ) -> bool:

--- a/aad_fastapi/roles/any_role_validator.py
+++ b/aad_fastapi/roles/any_role_validator.py
@@ -1,0 +1,8 @@
+import typing
+
+from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
+
+
+class AnyRoleValidator(RoleValidatorInterface):
+    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+        return any(mandatory_role in user_roles for mandatory_role in mandatory_roles)

--- a/aad_fastapi/roles/any_role_validator.py
+++ b/aad_fastapi/roles/any_role_validator.py
@@ -4,5 +4,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 
 class AnyRoleValidator(RoleValidatorInterface):
-    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+    def validate_roles(
+        self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
+    ) -> bool:
         return any(mandatory_role in user_roles for mandatory_role in mandatory_roles)

--- a/aad_fastapi/roles/any_role_validator.py
+++ b/aad_fastapi/roles/any_role_validator.py
@@ -5,6 +5,7 @@ from aad_fastapi.roles.role_validator_interface import RoleValidatorInterface
 
 class AnyRoleValidator(RoleValidatorInterface):
     """Validate that at least one mandatory role is present in the user roles"""
+
     def validate_roles(
         self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
     ) -> bool:

--- a/aad_fastapi/roles/role_requirement.py
+++ b/aad_fastapi/roles/role_requirement.py
@@ -2,5 +2,6 @@ from enum import Enum
 
 
 class RoleRequirement(Enum):
+    """Role requirement enum for authorization."""
     ALL = "all"
     ANY = "any"

--- a/aad_fastapi/roles/role_requirement.py
+++ b/aad_fastapi/roles/role_requirement.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class RoleRequirement(Enum):
+    ALL = "all"
+    ANY = "any"

--- a/aad_fastapi/roles/role_requirement.py
+++ b/aad_fastapi/roles/role_requirement.py
@@ -3,5 +3,6 @@ from enum import Enum
 
 class RoleRequirement(Enum):
     """Role requirement enum for authorization."""
+
     ALL = "all"
     ANY = "any"

--- a/aad_fastapi/roles/role_validator.py
+++ b/aad_fastapi/roles/role_validator.py
@@ -11,7 +11,9 @@ class RoleValidator:
         RoleRequirement.ANY: AnyRoleValidator,
     }
 
-    def __init__(self, mandatory_roles: typing.List[str], role_requirement: RoleRequirement):
+    def __init__(
+        self, mandatory_roles: typing.List[str], role_requirement: RoleRequirement
+    ):
         self.mandatory_roles = mandatory_roles
         self.role_requirement = role_requirement
         self.validator_class = self._validators.get(role_requirement)

--- a/aad_fastapi/roles/role_validator.py
+++ b/aad_fastapi/roles/role_validator.py
@@ -6,6 +6,7 @@ from aad_fastapi.roles.role_requirement import RoleRequirement
 
 
 class RoleValidator:
+    """Role validator class"""
     _validators = {
         RoleRequirement.ALL: AllRoleValidator,
         RoleRequirement.ANY: AnyRoleValidator,
@@ -21,5 +22,6 @@ class RoleValidator:
             raise ValueError(f"Invalid role requirement: {role_requirement}")
 
     def validate_roles(self, user_roles: typing.List[str]) -> bool:
+        """validate the user roles against the mandatory roles"""
         validator = self.validator_class()
         return validator.validate_roles(user_roles, self.mandatory_roles)

--- a/aad_fastapi/roles/role_validator.py
+++ b/aad_fastapi/roles/role_validator.py
@@ -1,0 +1,23 @@
+import typing
+
+from aad_fastapi.roles.all_role_validator import AllRoleValidator
+from aad_fastapi.roles.any_role_validator import AnyRoleValidator
+from aad_fastapi.roles.role_requirement import RoleRequirement
+
+
+class RoleValidator:
+    _validators = {
+        RoleRequirement.ALL: AllRoleValidator,
+        RoleRequirement.ANY: AnyRoleValidator,
+    }
+
+    def __init__(self, mandatory_roles: typing.List[str], role_requirement: RoleRequirement):
+        self.mandatory_roles = mandatory_roles
+        self.role_requirement = role_requirement
+        self.validator_class = self._validators.get(role_requirement)
+        if self.validator_class is None:
+            raise ValueError(f"Invalid role requirement: {role_requirement}")
+
+    def validate_roles(self, user_roles: typing.List[str]) -> bool:
+        validator = self.validator_class()
+        return validator.validate_roles(user_roles, self.mandatory_roles)

--- a/aad_fastapi/roles/role_validator.py
+++ b/aad_fastapi/roles/role_validator.py
@@ -7,6 +7,7 @@ from aad_fastapi.roles.role_requirement import RoleRequirement
 
 class RoleValidator:
     """Role validator class"""
+
     _validators = {
         RoleRequirement.ALL: AllRoleValidator,
         RoleRequirement.ANY: AnyRoleValidator,

--- a/aad_fastapi/roles/role_validator_interface.py
+++ b/aad_fastapi/roles/role_validator_interface.py
@@ -2,5 +2,7 @@ import typing
 
 
 class RoleValidatorInterface:
-    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+    def validate_roles(
+        self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
+    ) -> bool:
         pass

--- a/aad_fastapi/roles/role_validator_interface.py
+++ b/aad_fastapi/roles/role_validator_interface.py
@@ -5,4 +5,4 @@ class RoleValidatorInterface:
     def validate_roles(
         self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]
     ) -> bool:
-        pass
+        """validate the user roles against the mandatory roles"""

--- a/aad_fastapi/roles/role_validator_interface.py
+++ b/aad_fastapi/roles/role_validator_interface.py
@@ -1,0 +1,6 @@
+import typing
+
+
+class RoleValidatorInterface:
+    def validate_roles(self, user_roles: typing.Sequence[str], mandatory_roles: typing.Sequence[str]) -> bool:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,21 +75,25 @@ def mock_test_client(public_key):
     @app.get("/isauth_impersonation")
     @authorize("user_impersonation")
     async def get_isauth_with_impersonation(
-            request: Request, token=Depends(oauth2_scheme())
+        request: Request, token=Depends(oauth2_scheme())
     ):
         return request.user
 
     @app.get("/isauth_impersonation_all_roles")
     @authorize("user_impersonation", ["Admin", "Contributor"])
     async def get_isauth_with_impersonation_and_all_roles(
-            request: Request, token=Depends(oauth2_scheme())
+        request: Request, token=Depends(oauth2_scheme())
     ):
         return request.user
 
     @app.get("/isauth_impersonation_any_roles")
-    @authorize("user_impersonation", ["Admin", "Contributor"], role_requirement=RoleRequirement.ANY)
+    @authorize(
+        "user_impersonation",
+        ["Admin", "Contributor"],
+        role_requirement=RoleRequirement.ANY,
+    )
     async def get_isauth_with_impersonation_and_any_roles(
-            request: Request, token=Depends(oauth2_scheme())
+        request: Request, token=Depends(oauth2_scheme())
     ):
         return request.user
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,16 @@ import os
 import sys
 
 import pytest
-from aad_fastapi import AadBearerBackend, authorize, oauth2_scheme
-from async_asgi_testclient import TestClient
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI
 from fastapi.param_functions import Depends
+from fastapi.testclient import TestClient
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import Request
+
+from aad_fastapi import AadBearerBackend, authorize, oauth2_scheme
+from aad_fastapi.roles.role_requirement import RoleRequirement
 
 os.environ["CLIENT_ID"] = "01010101-aaaa-bbbb-acdf-020202020202"
 os.environ["TENANT_ID"] = "02020202-aaaa-erty-olki-020202020202"
@@ -49,7 +51,7 @@ def cert():
 
 
 @pytest.fixture(scope="module")
-def client(public_key):
+def mock_test_client(public_key):
     # pre fill client id
     swagger_ui_init_oauth = {
         "clientId": os.environ.get("CLIENT_ID"),
@@ -73,14 +75,21 @@ def client(public_key):
     @app.get("/isauth_impersonation")
     @authorize("user_impersonation")
     async def get_isauth_with_impersonation(
-        request: Request, token=Depends(oauth2_scheme())
+            request: Request, token=Depends(oauth2_scheme())
     ):
         return request.user
 
-    @app.get("/isauth_impersonation_roles")
+    @app.get("/isauth_impersonation_all_roles")
     @authorize("user_impersonation", ["Admin", "Contributor"])
-    async def get_isauth_with_impersonation_and_roles(
-        request: Request, token=Depends(oauth2_scheme())
+    async def get_isauth_with_impersonation_and_all_roles(
+            request: Request, token=Depends(oauth2_scheme())
+    ):
+        return request.user
+
+    @app.get("/isauth_impersonation_any_roles")
+    @authorize("user_impersonation", ["Admin", "Contributor"], role_requirement=RoleRequirement.ANY)
+    async def get_isauth_with_impersonation_and_any_roles(
+            request: Request, token=Depends(oauth2_scheme())
     ):
         return request.user
 

--- a/tests/test_authorize_decorator.py
+++ b/tests/test_authorize_decorator.py
@@ -6,31 +6,43 @@ from aad_fastapi import AzureAdSettings
 from tests.helpers import gen_payload
 
 
-@pytest.mark.parametrize("roles, expected_status_code", [
-    (["Admin", "Contributor"], 200),
-    (["Admin"], 403),
-    (["Contributor"], 403),
-    ([], 403)
-])
-def test_isauth_with_impersonation_and_all_roles(mock_test_client, private_key, roles, expected_status_code):
+@pytest.mark.parametrize(
+    "roles, expected_status_code",
+    [
+        (["Admin", "Contributor"], 200),
+        (["Admin"], 403),
+        (["Contributor"], 403),
+        ([], 403),
+    ],
+)
+def test_isauth_with_impersonation_and_all_roles(
+    mock_test_client, private_key, roles, expected_status_code
+):
     options = AzureAdSettings()
     payload = gen_payload(options, private_key, roles=roles, scp=["user_impersonation"])
     token = json.loads(payload)["access_token"]
-    response = mock_test_client.get("/isauth_impersonation_all_roles", headers={"Authorization": f"Bearer {token}"})
+    response = mock_test_client.get(
+        "/isauth_impersonation_all_roles", headers={"Authorization": f"Bearer {token}"}
+    )
     assert response.status_code == expected_status_code
 
 
 @pytest.mark.parametrize(
-    "roles,expected_status_code", [
+    "roles,expected_status_code",
+    [
         (["Admin", "Contributor"], 200),
         (["Admin"], 200),
         (["Contributor"], 200),
-        ([], 403)
-    ]
+        ([], 403),
+    ],
 )
-def test_valid_access_token_with_any_roles(mock_test_client, private_key, roles, expected_status_code):
+def test_valid_access_token_with_any_roles(
+    mock_test_client, private_key, roles, expected_status_code
+):
     options = AzureAdSettings()
     payload = gen_payload(options, private_key, roles=roles, scp=["user_impersonation"])
     token = json.loads(payload)["access_token"]
-    response = mock_test_client.get("/isauth_impersonation_any_roles", headers={"Authorization": f"Bearer {token}"})
+    response = mock_test_client.get(
+        "/isauth_impersonation_any_roles", headers={"Authorization": f"Bearer {token}"}
+    )
     assert response.status_code == expected_status_code

--- a/tests/test_authorize_decorator.py
+++ b/tests/test_authorize_decorator.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+
+from aad_fastapi import AzureAdSettings
+from tests.helpers import gen_payload
+
+
+@pytest.mark.parametrize("roles, expected_status_code", [
+    (["Admin", "Contributor"], 200),
+    (["Admin"], 403),
+    (["Contributor"], 403),
+    ([], 403)
+])
+def test_isauth_with_impersonation_and_all_roles(mock_test_client, private_key, roles, expected_status_code):
+    options = AzureAdSettings()
+    payload = gen_payload(options, private_key, roles=roles, scp=["user_impersonation"])
+    token = json.loads(payload)["access_token"]
+    response = mock_test_client.get("/isauth_impersonation_all_roles", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "roles,expected_status_code", [
+        (["Admin", "Contributor"], 200),
+        (["Admin"], 200),
+        (["Contributor"], 200),
+        ([], 403)
+    ]
+)
+def test_valid_access_token_with_any_roles(mock_test_client, private_key, roles, expected_status_code):
+    options = AzureAdSettings()
+    payload = gen_payload(options, private_key, roles=roles, scp=["user_impersonation"])
+    token = json.loads(payload)["access_token"]
+    response = mock_test_client.get("/isauth_impersonation_any_roles", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == expected_status_code

--- a/tests/test_role_validator.py
+++ b/tests/test_role_validator.py
@@ -7,57 +7,57 @@ from aad_fastapi.roles.role_requirement import RoleRequirement
 
 
 def test_role_validator_all():
-    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ALL)
-    user_roles = ['admin', 'editor']
+    validator = RoleValidator(["admin", "editor"], RoleRequirement.ALL)
+    user_roles = ["admin", "editor"]
     assert validator.validate_roles(user_roles)
 
 
 def test_role_validator_all_fail():
-    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ALL)
-    user_roles = ['admin']
+    validator = RoleValidator(["admin", "editor"], RoleRequirement.ALL)
+    user_roles = ["admin"]
     assert not validator.validate_roles(user_roles)
 
 
 def test_role_validator_any():
-    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ANY)
-    user_roles = ['admin']
+    validator = RoleValidator(["admin", "editor"], RoleRequirement.ANY)
+    user_roles = ["admin"]
     assert validator.validate_roles(user_roles)
 
 
 def test_role_validator_any_fail():
-    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ANY)
-    user_roles = ['guest']
+    validator = RoleValidator(["admin", "editor"], RoleRequirement.ANY)
+    user_roles = ["guest"]
     assert not validator.validate_roles(user_roles)
 
 
 def test_role_validator_invalid_role_requirement():
     with pytest.raises(ValueError):
-        RoleValidator([], 'invalid')
+        RoleValidator([], "invalid")
 
 
 def test_all_role_validator():
     validator = AllRoleValidator()
-    mandatory_roles = ['admin', 'editor']
-    user_roles = ['admin', 'editor']
+    mandatory_roles = ["admin", "editor"]
+    user_roles = ["admin", "editor"]
     assert validator.validate_roles(user_roles, mandatory_roles)
 
 
 def test_all_role_validator_fail():
     validator = AllRoleValidator()
-    mandatory_roles = ['admin', 'editor']
-    user_roles = ['admin']
+    mandatory_roles = ["admin", "editor"]
+    user_roles = ["admin"]
     assert not validator.validate_roles(user_roles, mandatory_roles)
 
 
 def test_any_role_validator():
     validator = AnyRoleValidator()
-    mandatory_roles = ['admin', 'editor']
-    user_roles = ['admin']
+    mandatory_roles = ["admin", "editor"]
+    user_roles = ["admin"]
     assert validator.validate_roles(user_roles, mandatory_roles)
 
 
 def test_any_role_validator_fail():
     validator = AnyRoleValidator()
-    mandatory_roles = ['admin', 'editor']
-    user_roles = ['guest']
+    mandatory_roles = ["admin", "editor"]
+    user_roles = ["guest"]
     assert not validator.validate_roles(user_roles, mandatory_roles)

--- a/tests/test_role_validator.py
+++ b/tests/test_role_validator.py
@@ -1,0 +1,63 @@
+import pytest
+
+from aad_fastapi.roles.role_validator import RoleValidator
+from aad_fastapi.roles.any_role_validator import AnyRoleValidator
+from aad_fastapi.roles.all_role_validator import AllRoleValidator
+from aad_fastapi.roles.role_requirement import RoleRequirement
+
+
+def test_role_validator_all():
+    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ALL)
+    user_roles = ['admin', 'editor']
+    assert validator.validate_roles(user_roles)
+
+
+def test_role_validator_all_fail():
+    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ALL)
+    user_roles = ['admin']
+    assert not validator.validate_roles(user_roles)
+
+
+def test_role_validator_any():
+    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ANY)
+    user_roles = ['admin']
+    assert validator.validate_roles(user_roles)
+
+
+def test_role_validator_any_fail():
+    validator = RoleValidator(['admin', 'editor'], RoleRequirement.ANY)
+    user_roles = ['guest']
+    assert not validator.validate_roles(user_roles)
+
+
+def test_role_validator_invalid_role_requirement():
+    with pytest.raises(ValueError):
+        RoleValidator([], 'invalid')
+
+
+def test_all_role_validator():
+    validator = AllRoleValidator()
+    mandatory_roles = ['admin', 'editor']
+    user_roles = ['admin', 'editor']
+    assert validator.validate_roles(user_roles, mandatory_roles)
+
+
+def test_all_role_validator_fail():
+    validator = AllRoleValidator()
+    mandatory_roles = ['admin', 'editor']
+    user_roles = ['admin']
+    assert not validator.validate_roles(user_roles, mandatory_roles)
+
+
+def test_any_role_validator():
+    validator = AnyRoleValidator()
+    mandatory_roles = ['admin', 'editor']
+    user_roles = ['admin']
+    assert validator.validate_roles(user_roles, mandatory_roles)
+
+
+def test_any_role_validator_fail():
+    validator = AnyRoleValidator()
+    mandatory_roles = ['admin', 'editor']
+    user_roles = ['guest']
+    assert not validator.validate_roles(user_roles, mandatory_roles)


### PR DESCRIPTION
### Summary :memo:
Add role requirements to `@authorize` decorator, allowing for authorization based on some or all of the required roles and scopes. Also added tests to cover these new requirements.

### Details
The @authorize decorator has been updated to allow for `role_requirement` to be specified. The decorator now takes an additional argument, `role_requirement`, which is optional. 
If `role_requirement=RoleRequirement.ALL` is specified, the user must have all of the roles listed in their token in order to access the endpoint, which is the default behavior as well if not specified.

for example:
`@authorize(roles=["admin1","admin2"],role_requirement=RoleRequirement.ALL)`
user must be both admin1 and admin 2 to access

and if one or more of the roles is required you would need to use `role_requirement=RoleRequirement.ANY` instead
for example:
`@authorize(roles=["admin","user"],role_requirement=RoleRequirement.ANY)`
user must be one of `admin` or `user` to access

The tests have also been updated to cover these new requirements and new tests have been added to cover the roles validator functionality.

### Checks
- [x] Tested Changes
- [x] Stakeholder Approval